### PR TITLE
Change ExprTk by muParser, detects if a result is integer and adds mi…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/exprtk"]
-	path = lib/exprtk
-	url = https://github.com/ArashPartow/exprtk.git
 [submodule "test/googletest"]
 	path = test/googletest
 	url = https://github.com/google/googletest.git

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 EXECUTABLE_NAME = tcalc
 CXX             = g++
-CXX_FLAGS       = -g -std=c++11 -lncurses -Wall
+CXX_FLAGS       = -g -std=c++11 -lncurses -lmuparser -Wall
 
 all: tcalc.cpp
 	$(CXX) $(CXX_FLAGS) -o $(EXECUTABLE_NAME) tcalc.cpp

--- a/calculator.cpp
+++ b/calculator.cpp
@@ -8,11 +8,12 @@
 
 //#include <ncurses.h>
 #include "wrapped_ncurses.hpp"
-#include "lib/exprtk/exprtk.hpp"
 
 #include "calculator.hpp"
 #include "calculator/keys.hpp"
 #include "calculator/component.hpp"
+
+#include <muParser.h>
 
 void initcolor() {
     if (ncurses::has_colors() != FALSE) {
@@ -277,8 +278,17 @@ void Calculator::key_enter() {
         // execute buffered equation
         std::string expression_string = joinStrVec(buffered_equation) + 
             joinStrVec(buffered_partial_op_string);
-        double res = calculate<double>(expression_string);
-        main_display->setResult(std::to_string(res));
+        try {
+            double res = calculate<double>(expression_string);
+            int res_int = (int)res;
+            // Convert to integer if result has no decimals
+            if (res == res_int) { main_display->setResult(std::to_string(res_int)); }
+            else { main_display->setResult(std::to_string(res)); }
+        }
+        catch (mu::Parser::exception_type &e) {
+            //main_display->setResult(e.GetMsg());
+            main_display->setResult("nan");
+        }
         main_display->redisplay();
     } else {
         btn_t bt = buttons[selected_button_idx]->getAttribute().bt;

--- a/calculator.hpp
+++ b/calculator.hpp
@@ -11,9 +11,13 @@
 #include <cstring>
 #include <algorithm>
 #include <ncurses.h>
-#include "lib/exprtk/exprtk.hpp"
+#include <muParser.h>
+#include <cmath>
 
 #include "calculator/keys.hpp"
+
+// This macro will enable mathematical constants (like M_PI) in muParser.
+#define _USE_MATH_DEFINES		
 
 namespace std {
 template<typename T, typename... Ts>
@@ -64,6 +68,27 @@ class Calculator {
     class ButtonComponent;
     class KeyHelpComponent;
 
+    /// Base N logarithm    
+    double logn(double x, double base) { return log(x) / log(base); }
+    
+    /// Nth-Root of x
+    double root(double input, double n) { return round(pow(input, 1./n)); }
+
+    /// Cotangent
+    double cot(double x) { return cos(x) / sin(x); }
+
+    /// Cosecant
+    double csc(double x) { return 1 / sin(x); }
+
+    /// Secant
+    double sec(double x) { return 1 / cos(x); }
+
+    /// Sine cardinal
+    double sinc(double x) { return sin(x) / x; }
+
+    /// Normalized sine cardinal (normally used in digital signal processing)
+    double sincN(double x) { return sin(M_PI * x) / M_PI * x; }
+    
     /// Default constructor constructs a calculator object with default settings.
     Calculator() : Calculator(getDefaultButtonAttributes()) {};
 
@@ -144,16 +169,23 @@ class Calculator {
     };
 
     /// Evaluate input expression string as an mathematical expression.
-    /// Completely depends on exprtk.
+    /// Completely depends on muParser.
     template <typename T>
     T calculate(std::string expression_string) {
-        //using symbol_table_t = exprtk::symbol_table<T>;
-        using expression_t   = exprtk::expression<T>;
-        using parser_t       = exprtk::parser<T>;
-        expression_t expression;
-        parser_t parser;
-        parser.compile(expression_string, expression);
-        return expression.value();
+        mu::Parser parser;
+        parser.DefineConst("pi", M_PI);
+        parser.DefineConst("e", M_E);
+        // Some missing functions
+        /*parser.DefineFun("logn", logn);
+        parser.DefineFun("root", root);
+        parser.DefineFun("cot", cot);
+        parser.DefineFun("csc", csc);
+        parser.DefineFun("sec", sec);
+        parser.DefineFun("sinc", sinc);
+        parser.DefineFun("sincN", sincN);*/
+        parser.SetExpr(expression_string);
+        T result=parser.Eval();
+        return result;
     };
 
   protected:


### PR DESCRIPTION
Change the parser by [muParser](http://beltoforion.de/article.php?a=muparser) because of the following:
* With muParser the program compiles faster and the executable weighs almost 12 times less than the original as you can see in this comparison that I did:
	```
	# With ExprTk
	~/tcalc $ time make
	g++ -g -std=c++11 -lncurses -Wall -o tcalc tcalc.cpp
	
	real	1m9.823s
	user	1m1.409s
	sys	0m2.124s
	~/tcalc $ wc -c tcalc |  awk '{ mb = $1 /1048576 ; printf("%d bytes (%f MB)\n", $1, mb) }'
	20877136 bytes (19.909988 MB)
	
	# With muParser
	~/tcalc $ time make
	g++ -g -std=c++11 -lncurses -lmuparser -Wall -o tcalc tcalc.cpp
	
	real	0m5.443s
	user	0m5.018s
	sys	0m0.246s
	~/tcalc $ wc -c tcalc |  awk '{ mb = $1 /1048576 ; printf("%d bytes (%f MB)\n", $1, mb) }'
	1759432 bytes (1.677925 MB)
	```
* Although it does not have many integrated functions like ExprTk, these can be added with [DefineFun](http://beltoforion.de/article.php?a=muparser&hl=en&p=defining_functions). Unfortunately when trying to add the missing functions in the parser, and no matter what I do, the following appears when I run the make command:
	```
	In file included from calculator.cpp:12:0,
	                 from tcalc.cpp:9:
	calculator.hpp: In member function 'T Calculator::calculate(std::__cxx11::string)':
	calculator.hpp:179:38: error: invalid use of non-static member function
	         parser.DefineFun("logn", logn);
	                                      ^
	calculator.hpp:180:38: error: invalid use of non-static member function
	         parser.DefineFun("root", root);
	                                      ^
	calculator.hpp:181:36: error: invalid use of non-static member function
	         parser.DefineFun("cot", cot);
	                                    ^
	calculator.hpp:182:36: error: invalid use of non-static member function
	         parser.DefineFun("csc", csc);
	                                    ^
	calculator.hpp:183:36: error: invalid use of non-static member function
	         parser.DefineFun("sec", sec);
	                                    ^
	calculator.hpp:184:38: error: invalid use of non-static member function
	         parser.DefineFun("sinc", sinc);
	                                      ^
	calculator.hpp:185:40: error: invalid use of non-static member function
	         parser.DefineFun("sincN", sincN);
	                                        ^
	make: *** [Makefile:8: all] Error 1
	```
	However, I left them defined in calculator.hpp in case you know how to solve this.
* Another advantage of muParser is that it is available in many distributions, which would facilitate packaging the program (in case you someday want to make an installer).

Other minor changes were convert the result to integer if it does not have decimals and the function sincN (although remains pending to add the corresponding button).